### PR TITLE
Add submodules and requirement for `future` package to setup

### DIFF
--- a/appy/setup_info.py
+++ b/appy/setup_info.py
@@ -8,6 +8,7 @@ SETUP_INFO = dict(
     author='Luc Saffre',
     author_email='luc@saffre-rumma.net',
     url="http://appypod.lino-framework.org",
+    install_requires = ['future'],
     long_description="""\
 
 The `appypod` project is a partial redistribution of Gaetan Delannay's
@@ -80,8 +81,12 @@ Operating System :: OS Independent""".splitlines())
 SETUP_INFO.update(packages=[n for n in """
 appy
 appy.pod
+appy.http
+appy.model
+appy.px
+appy.ui
+appy.utils
+appy.xml
 """.splitlines() if n])
 
 SETUP_INFO.update(package_data=dict())
-
-


### PR DESCRIPTION
Hi there,

I have a business application that has been kept to Python 2.7 for a while just because of `appy.pod`, so I was very happy to discover your port this morning. I am using Python 3.6 on Ubuntu 16.04 and after doing the following changes to your setup procedure, I was able to make it work. I tested it with both ODT and PDF rendering, and it seems to work well. However for PDF rendering things are a bit more tricky because it seems that the `python3-uno` OS-level package (and possibly some others) is required. I tried `pip install`ing the `uno` and `unotools` Python packages, but they seem to be different. Anyway, I hope this PR might be useful, and thanks again for the nice port!